### PR TITLE
Button fix

### DIFF
--- a/src/UI/Button/Button.module.scss
+++ b/src/UI/Button/Button.module.scss
@@ -41,8 +41,7 @@
   }
 
   &__number,
-  &__icon,
-  &__favorites {
+  &__icon {
     aspect-ratio: 1 / 1;
     background-color: $White;
     border: 1px solid;

--- a/src/UI/Button/Button.module.scss
+++ b/src/UI/Button/Button.module.scss
@@ -4,6 +4,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  width: var(--btn-width);
+  height: var(--btn-height);
   line-height: 21px;
   font-size: 14px;
   font-weight: 700;
@@ -39,9 +41,9 @@
   }
 
   &__number,
-  &__icon {
-    width: 40px;
-    height: 40px;
+  &__icon,
+  &__favorites {
+    aspect-ratio: 1 / 1;
     background-color: $White;
     border: 1px solid;
   }

--- a/src/UI/Button/Button.tsx
+++ b/src/UI/Button/Button.tsx
@@ -5,8 +5,21 @@ import styles from './Button.module.scss';
 import { makeColorDarker } from '../../utils/makeColorDarker';
 import ArrowLeft from '../../assets/icons/ArrowLeftBold.svg';
 
+type Size = {
+  width?: number;
+  height: number;
+};
+
+interface CustomCSSProperties extends React.CSSProperties {
+  '--btn-width': string;
+  '--btn-height': string;
+  '--radio-color'?: string;
+  '--radio-hover-color'?: string;
+}
+
 type ButtonProps = {
   type: 'number' | 'radio' | 'icon' | 'back' | 'primary';
+  size: Size;
   state?: 'selected' | 'disabled';
   color?: string;
   onClick?: () => void;
@@ -16,6 +29,7 @@ type ButtonProps = {
 const Button: React.FC<ButtonProps> = ({
   type,
   state,
+  size,
   color,
   onClick,
   children,
@@ -25,13 +39,16 @@ const Button: React.FC<ButtonProps> = ({
   });
 
   const darkerColor = color ? makeColorDarker(color, 15) : undefined;
-  const style =
-    type === 'radio' && color
-      ? ({
+  const style: CustomCSSProperties = {
+    '--btn-width': `${size.width}px`,
+    '--btn-height': `${size.height}px`,
+    ...(type === 'radio' && color
+      ? {
           '--radio-color': color,
           '--radio-hover-color': darkerColor,
-        } as React.CSSProperties)
-      : {};
+        }
+      : {}),
+  };
 
   return (
     <button className={btnClass} onClick={onClick} style={style}>


### PR DESCRIPTION
Now you can add required props size as object {width: height:}, where height is required. If you dont input width it will adjust - for primary - will take 100% of free space, for icons - will be same as height to preserve square form